### PR TITLE
Use asset_path to locate images

### DIFF
--- a/vendor/assets/javascripts/leaflet.js.erb
+++ b/vendor/assets/javascripts/leaflet.js.erb
@@ -2282,12 +2282,12 @@ L.Icon = L.Class.extend({
 
 L.Icon.Default = L.Icon.extend({
 	options: {
-		iconUrl: L.ROOT_URL + 'images/marker.png',
+    iconUrl: "<%= asset_path('marker.png') %>",
 		iconSize: new L.Point(25, 41),
 		iconAnchor: new L.Point(13, 41),
 		popupAnchor: new L.Point(0, -33),
 
-		shadowUrl: L.ROOT_URL + 'images/marker-shadow.png',
+    shadowUrl: "<%= asset_path('marker-shadow.png') %>",
 		shadowSize: new L.Point(41, 41)
 	}
 });

--- a/vendor/assets/stylesheets/leaflet.css.erb
+++ b/vendor/assets/stylesheets/leaflet.css.erb
@@ -154,11 +154,11 @@ a.leaflet-active {
 	height: 27px;
 	}
 .leaflet-control-zoom-in {
-	background-image: url(zoom-in.png);
+	background-image: url(<%= asset_path 'zoom-in.png' %>);
 	margin-bottom: 5px;
 	}
 .leaflet-control-zoom-out {
-	background-image: url(zoom-out.png);
+	background-image: url(<%= asset_path 'zoom-out.png' %>);
 	}
 
 .leaflet-control-layers {
@@ -169,7 +169,7 @@ a.leaflet-active {
 	border-radius: 8px;
 	}
 .leaflet-control-layers a {
-	background-image: url(layers.png);
+	background-image: url(<%= asset_path 'layers.png' %>);
 	width: 36px;
 	height: 36px;
 	}


### PR DESCRIPTION
This is needed for marker images to be located properly. For consistency I use the same technique to locate the zoom and layer control images.
