### PR TITLE
Fix icon image URLs with rails asset pipeline.

### DIFF
--- a/vendor/assets/javascripts/leaflet.js.erb
+++ b/vendor/assets/javascripts/leaflet.js.erb
@@ -3360,16 +3360,14 @@ L.Icon.Default = L.Icon.extend({
 		}
 
 		if (L.Browser.retina && name === 'icon') {
-			name += '-2x';
+			return "<%= asset_path('marker-icon-2x.png') %>";
 		}
 
-		var path = L.Icon.Default.imagePath;
-
-		if (!path) {
-			throw new Error('Couldn\'t autodetect L.Icon.Default.imagePath, set it manually.');
+		if (name == 'shadow') {
+			return "<%= asset_path('marker-shadow.png') %>";
+		} else {
+			return "<%= asset_path('marker-icon.png') %>";
 		}
-
-		return path + '/marker-' + name + '.png';
 	}
 });
 


### PR DESCRIPTION
Restores icon and icon-shadow asset path logic like #2 with new retina icon.
