### PR TITLE
Add images to precompile option for rails 4.0.

### DIFF
--- a/lib/leaflet-rails.rb
+++ b/lib/leaflet-rails.rb
@@ -3,7 +3,9 @@ require "leaflet-rails/version"
 module Leaflet
   module Rails
     class Engine < ::Rails::Engine
-      # Rails -> use vendor directory.
+      initializer 'leaflet-rails.precompile' do |app|
+        app.config.assets.precompile += %w(layers-2x.png layers.png marker-icon-2x.png marker-icon.png marker-shadow.png)
+      end
     end
   end
 end


### PR DESCRIPTION
Rails 4.0 does not precompile non-JS/CSS assets in `vendor` anymore. They need to be added to precompile option by the engine.
