### PR TITLE
Adds depend_on_assets directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ After that, open your application-wide Javascript file (typically `app/assets/ja
 
 At this point, you may skip the first two steps of the [Leaflet Quick Start guide](http://leafletjs.com/examples/quick-start.html) and start at the third step (adding the map `div` to a view).
 
+*Rails 4.1+*
+
+If you are using Rails 4.1+ you will need to open your application-wide CSS file (`app/assets/stylesheets/application.css`) and add the following lines at the top:
+
+```
+//= depend_on_asset "layers.png"
+//= depend_on_asset "layers-2x.png"
+```
+
 Helpers
 =======
 

--- a/vendor/assets/javascripts/leaflet.js.erb
+++ b/vendor/assets/javascripts/leaflet.js.erb
@@ -3,6 +3,11 @@
  (c) 2010-2013, Vladimir Agafonkin
  (c) 2010-2011, CloudMade
 */
+
+//= depend_on_asset "marker-icon-2x.png"
+//= depend_on_asset "marker-shadow.png"
+//= depend_on_asset "marker-icon.png"
+
 (function (window, document, undefined) {
 var oldL = window.L,
     L = {};


### PR DESCRIPTION
Plays nicely with https://github.com/schneems/sprockets_better_errors and with Rails 4.1 both of which require `//= depend_on_assets` directives if the asset depends on other assets like an image. In this case the `leaflet.js.erb` depends on the marker images.
