### PR TITLE
Add fit_to_markers option to automatically zoom and display all markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ map(:center => {
 )
 ```
 
+To automatically zoom and position the map so all your markers are visible when it displays, add the ```fit_to_markers``` option:
+```ruby
+map(
+  :markers => [
+     {
+       :latlng => [51.52238797921441, -0.08366235665359283],
+       :popup => "Hello!"
+     }
+  ].
+  :fit_to_markers => true
+)
+```
+
+If you specify both ```fit_to_markers``` and ```fitbounds``` on a map, the value of ```fitbounds``` will take precendence.
+
 Adding a `:popup` element to a marker hash will also generate a popup for a maker:
 
 ```ruby

--- a/lib/leaflet-rails/view_helpers.rb
+++ b/lib/leaflet-rails/view_helpers.rb
@@ -45,6 +45,12 @@ module Leaflet
         end
       end
 
+      if options[:fit_to_markers] && options[:markers] && (options[:markers].count > 1)
+        locations = options[:markers].collect { |m| [m[:latlng][0].to_f, m[:latlng][1].to_f]  }
+
+        output << "map.fitBounds( L.latLngBounds( #{locations} ) );"
+      end
+
       if circles
         circles.each do |circle|
           output << "L.circle(['#{circle[:latlng][0]}', '#{circle[:latlng][1]}'], #{circle[:radius]}, {


### PR DESCRIPTION
Adds an option to calculate the bounding box of the markers and automatically zoom and centre the location so they are all visible.
