### PR TITLE
Add interaction options to map helper.

### DIFF
--- a/lib/leaflet-rails/view_helpers.rb
+++ b/lib/leaflet-rails/view_helpers.rb
@@ -8,6 +8,7 @@ module Leaflet
       options[:max_zoom] ||= Leaflet.max_zoom
       options[:subdomains] ||= Leaflet.subdomains
       options[:container_id] ||= 'map'
+      options[:interaction] ||= {}
 
       tile_layer = options.delete(:tile_layer) || Leaflet.tile_layer
       attribution = options.delete(:attribution) || Leaflet.attribution
@@ -19,12 +20,13 @@ module Leaflet
       circles = options.delete(:circles)
       polylines = options.delete(:polylines)
       fitbounds = options.delete(:fitbounds)
+      interaction = options.delete(:interaction)
 
 
       output = []
       output << "<div id='#{container_id}'></div>" unless no_container
       output << "<script>"
-      output << "var map = L.map('#{container_id}')"
+      output << "var map = L.map('#{container_id}', #{interaction.to_json})"
 
       if center
         output << "map.setView([#{center[:latlng][0]}, #{center[:latlng][1]}], #{center[:zoom]})"

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -36,6 +36,19 @@ describe Leaflet::ViewHelpers do
 	  result.should match(/map\.setView\(\[51.52238797921441, -0.08366235665359283\], 18\)/)
   end
   
+  it 'should generate a basic map with the correct scrollWhellZoom option' do
+    result = @view.map(
+      :center => {
+        :latlng => [51.52238797921441, -0.08366235665359283],
+        :zoom => 18
+      },
+      :interaction => {
+        :scrollWheelZoom => false
+      }
+    )
+    result.should match(/var map = L.map\('map', {"scrollWheelZoom":false}\)/)
+  end
+
   it 'should generate a marker' do
     result = @view.map(:center => {
 	      :latlng => [51.52238797921441, -0.08366235665359283],


### PR DESCRIPTION
This adds the ability to pass [interaction options](http://leafletjs.com/reference.html#map-dragging) when creating the map.

I needed the [`scrollWheelZoom`](http://leafletjs.com/reference.html#map-scrollwheelzoom) option set to `false`. It prevents unintended map zoom when the user scrolls through the page with a scroll-wheel.
