### PR TITLE
Don't set subdomains if they're nil

### DIFF
--- a/lib/leaflet-rails/view_helpers.rb
+++ b/lib/leaflet-rails/view_helpers.rb
@@ -40,7 +40,7 @@ module Leaflet
             output << "marker = L.marker([#{marker[:latlng][0]}, #{marker[:latlng][1]}]).addTo(map);"
           end
           if marker[:popup]
-            output << "marker.bindPopup('#{marker[:popup]}');"
+            output << "marker.bindPopup('#{escape_javascript marker[:popup]}');"
           end
         end
       end

--- a/lib/leaflet-rails/view_helpers.rb
+++ b/lib/leaflet-rails/view_helpers.rb
@@ -72,9 +72,8 @@ module Leaflet
           attribution: '#{attribution}',
           maxZoom: #{max_zoom},"
 
-      if options[:subdomains]
-        output << "    subdomains: #{options[:subdomains]},"
-        options.delete( :subdomains )
+      if subdomains = options.delete(:subdomains)
+        output << "    subdomains: #{subdomains},"
       end
 
       options.each do |key, value|

--- a/spec/view_helpers_spec.rb
+++ b/spec/view_helpers_spec.rb
@@ -27,6 +27,22 @@ describe Leaflet::ViewHelpers do
 	  expect(result).to match(/attribution: 'Some attribution statement'/)
 	  expect(result).to match(/maxZoom: 18/)
   end
+  
+  it 'should set subdomains if present' do
+    result = @view.map(:center => {
+	      :latlng => [51.52238797921441, -0.08366235665359283],
+	      :zoom => 18
+	  	}, :subdomains => ['otile1', 'otile2'])
+    expect(result).to match(/subdomains: \["otile1", "otile2"\]/)
+  end
+  
+  it 'should not set subdomains if nil' do
+    result = @view.map(:center => {
+	      :latlng => [51.52238797921441, -0.08366235665359283],
+	      :zoom => 18
+	  	}, :subdomains => nil)
+    expect(result).not_to match(/subdomains:/)
+  end
 
   it 'should generate a basic map with the correct latitude, longitude and zoom' do
     result = @view.map(:center => {


### PR DESCRIPTION
By default when using OpenStreetMap tiles with no subdomains parameter passed, there's an error, because:

1. `options[:subdomains] ||= Leaflet.subdomains` sets `options[:subdomains]` to nil.
2. The `if options[:subdomains]` never fires.
3. The `:subdomains` is never deleted from `options`.
4. The generic option parser at the end catches it and outputs an invalid `subdomains: ''`.

This PR moves the delete into the if statement, so the item is deleted whether or not the if returns true. I've also added some specs for both the positive and negative case.