### PR TITLE
fixed paths of icons for leaflet 1.0.2

### DIFF
--- a/vendor/assets/javascripts/leaflet.js.erb
+++ b/vendor/assets/javascripts/leaflet.js.erb
@@ -4,11 +4,10 @@
 //= require leaflet-src
 <% icons = ['icon-2x.png', 'shadow.png', 'icon.png'] %>
 
-L.Icon.Default = L.Icon.Default.extend({
-	_getIconUrl: function (name) {
-		var paths = <%= Hash[icons.map{|i| [i, asset_path('marker-' + i)]}].to_json %>;
-		return paths[name + '.png'];
-	},
+L.Icon.Default.imagePath = (function () {
+  return ' ';
+}());
 
-	_detectIconPath: function () { }
-});
+L.Icon.Default.prototype.options.iconUrl = '<%= asset_path 'marker-icon.png'%>';
+L.Icon.Default.prototype.options.iconRetinaUrl = '<%= asset_path 'marker-icon-2x.png'%>';
+L.Icon.Default.prototype.options.shadowUrl = '<%= asset_path 'marker-shadow.png'%>';


### PR DESCRIPTION
This pull shall fix url for the marker icons for leaflet 1.0.2. Note that it is kind of different approach for specifying the paths from the original one, so you might consider rewriting the solution so that it better fits your structure.