### PR TITLE
Seems to fix the asset digest issue reported in issue #59

### DIFF
--- a/vendor/assets/javascripts/leaflet-src.js.erb
+++ b/vendor/assets/javascripts/leaflet-src.js.erb
@@ -6246,9 +6246,9 @@ L.icon = function (options) {
 L.Icon.Default = L.Icon.extend({
 
 	options: {
-		iconUrl:       'marker-icon.png',
-		iconRetinaUrl: 'marker-icon-2x.png',
-		shadowUrl:     'marker-shadow.png',
+		iconUrl:       '<%= Rails.application.assets.find_asset("marker-icon.png").digest_path %>',
+		iconRetinaUrl: '<%= Rails.application.assets.find_asset("marker-icon-2x.png").digest_path %>',
+		shadowUrl:     '<%= Rails.application.assets.find_asset("marker-shadow.png").digest_path %>',
 		iconSize:    [25, 41],
 		iconAnchor:  [12, 41],
 		popupAnchor: [1, -34],

--- a/vendor/assets/javascripts/leaflet-src.js.erb
+++ b/vendor/assets/javascripts/leaflet-src.js.erb
@@ -6276,7 +6276,7 @@ L.Icon.Default = L.Icon.extend({
 		document.body.removeChild(el);
 
 		return path.indexOf('url') === 0 ?
-			path.replace(/^url\([\"\']?/, '').replace(/marker-icon\.png[\"\']?\)$/, '') : '';
+			path.replace(/^url\([\"\']?/, '').replace(/marker-icon-<%= Rails.application.assets.find_asset('marker-icon.png').digest %>\.png[\"\']?\)$/, '') : '';
 	}
 });
 

--- a/vendor/assets/stylesheets/leaflet.css.erb
+++ b/vendor/assets/stylesheets/leaflet.css.erb
@@ -381,7 +381,7 @@
 
 /* Default icon URLs */
 .leaflet-default-icon-path {
-	background-image: url(<%= asset_path 'marker-icon.png' %>);
+	background-image: url(<%= Rails.application.assets.find_asset("marker-icon.png").digest_path %>);
 	}
 
 


### PR DESCRIPTION
There is probably a nicer way to deal with this. I have added digests to the marker urls, as the default functionality was not playing nicely; tested in dev and production