### PR TITLE
Make rails a dependency

### DIFF
--- a/leaflet-rails.gemspec
+++ b/leaflet-rails.gemspec
@@ -19,9 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency "rails", '>= 4.2.0'
   s.add_development_dependency "rspec", '<= 3.4.0'
   s.add_development_dependency "simplecov-rcov"
-  s.add_development_dependency "actionpack", '>= 4.2.0'
-  s.add_development_dependency "activesupport", '>= 4.2.0'
-  s.add_development_dependency "railties", '>= 4.2.0'
 end

--- a/lib/leaflet-rails.rb
+++ b/lib/leaflet-rails.rb
@@ -1,5 +1,6 @@
 require "leaflet-rails/version"
 require "leaflet-rails/view_helpers"
+require "rails"
 
 module Leaflet
   mattr_accessor :tile_layer


### PR DESCRIPTION
This fixes #65 - it's not just `mattr_accessor` that comes from Rails, but `Rails::Engine` itself.

I believe Rails is a full dependency, not just a development dependency.