### PR TITLE
Fix marker icon override for 1.x

### DIFF
--- a/vendor/assets/javascripts/leaflet.js.erb
+++ b/vendor/assets/javascripts/leaflet.js.erb
@@ -12,3 +12,8 @@ L.Icon.Default = L.Icon.Default.extend({
 
 	_detectIconPath: function () { }
 });
+L.Marker = L.Marker.extend({
+  options: {
+    icon: new L.Icon.Default()
+  }
+});


### PR DESCRIPTION
This is an alternative fix for the issue fixed in #57 - @axyjo's code was fine. The problem was only that the L.Marker is extended before that code has a chance to run.

This adds a few lines to the end of the override JS that rerun just the relevant part of the upstream code, and this fixes the marker URL.