### PR TITLE
Allow marker popup to open on map load

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ map(:center => {
 )
 ```
 
-Adding a `:popup` element to a marker hash will also generate a popup for a maker:
+Adding a `:popup` element to a marker hash will also generate a popup for a maker. There is also an optional `:open_popup` element that can be set to open the popup on map load:
 
 ```ruby
 map(:center => {
@@ -89,10 +89,15 @@ map(:center => {
     :zoom => 18
   },
   :markers => [
-     {
-       :latlng => [51.52238797921441, -0.08366235665359283],
-       :popup => "Hello!"
-     }
+    {
+      :latlng => [51.52238797921441, -0.08366235665359283],
+      :popup => "This popup will not display on page load."
+    },
+    {
+      :latlng => [51.5225425, -0.0847174,17.58],
+      :popup => "This popup will display on page load.",
+      :open_popup => true
+    }
   ]
 )
 ```

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ map(:center => {
   ]
 )
 ```
+The default value for `:open_popup` can be changed by specifying `Leaflet.open_popups = true` in the initializer.
 
 If you want to override the map settings you have set in the initializer, you can also add them to the helper method:
 

--- a/lib/leaflet-rails.rb
+++ b/lib/leaflet-rails.rb
@@ -7,7 +7,8 @@ module Leaflet
   mattr_accessor :attribution
   mattr_accessor :max_zoom
   mattr_accessor :subdomains
-  
+  mattr_accessor :open_popups
+
   module Rails
     class Engine < ::Rails::Engine
       initializer 'leaflet-rails.precompile' do |app|

--- a/lib/leaflet-rails/view_helpers.rb
+++ b/lib/leaflet-rails/view_helpers.rb
@@ -43,7 +43,7 @@ module Leaflet
           end
           if marker[:popup]
             output << "marker.bindPopup('#{escape_javascript marker[:popup]}')"
-            output << '.openPopup()' if marker[:open_popup]
+            output << '.openPopup()' if marker[:open_popup].present? ? marker[:open_popup] : Leaflet.open_popups
             output << ';';
           end
         end

--- a/lib/leaflet-rails/view_helpers.rb
+++ b/lib/leaflet-rails/view_helpers.rb
@@ -42,7 +42,9 @@ module Leaflet
             output << "marker = L.marker([#{marker[:latlng][0]}, #{marker[:latlng][1]}]).addTo(map);"
           end
           if marker[:popup]
-            output << "marker.bindPopup('#{escape_javascript marker[:popup]}');"
+            output << "marker.bindPopup('#{escape_javascript marker[:popup]}')"
+            output << '.openPopup()' if marker[:open_popup]
+            output << ';';
           end
         end
       end


### PR DESCRIPTION
Allows specifying an open_popup value in the marker hash which opens the popup automatically on page load.

Example:
```ruby
map(:center => {
    :latlng => [51.52238797921441, -0.08366235665359283],
    :zoom => 18
  },
  :markers => [
    {
      :latlng => [51.52238797921441, -0.08366235665359283],
      :popup => "This popup will not display on page load."
    },
    {
      :latlng => [51.5225425, -0.0847174,17.58],
      :popup => "This popup will display on page load.",
      :open_popup => true
    }
  ]
)
```

Will not do anything when `popup` is not specified.

Also adds a config option that would allow the default value for this to be true called `Leaflet.open_popups`. Can be omitted by omitting the relevant commit if people think this does not add enough value. The check to use the default value or the specified value feels like it could be more elegant, but methods such as combining `.presence` and || do not work since `open_popup` is a boolean.